### PR TITLE
SMP-1163: Fixed 'create_config_service failed' log message

### DIFF
--- a/src/timescale/templates/role-timescaledb.yaml
+++ b/src/timescale/templates/role-timescaledb.yaml
@@ -47,7 +47,7 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs:
-#  - create
+  - create
   - get
   - list
 #  - patch


### PR DESCRIPTION
### What caused the issue?
This issue was due to an underlying issue in the patroni library ([here](https://github.com/timescale/helm-charts/issues/405)).

### How was it fixed?
 The fix is to add the `create` permission in the `services` api-group ([here](https://github.com/timescale/helm-charts/issues/405#issuecomment-1197577391))
Although this is a workaround, as this issue doesn't affect the functioning of timescale-db, only adds unnecessary logging, an actual fix is available in patroni([here](https://github.com/zalando/patroni/pull/2390)) but it hasn't found it's way to the official timescale-db image until then this workaround should stop the logs without any other implications.