### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/timescale/Chart.yaml
+++ b/src/timescale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: TimescaleDB HA Deployment.
 home: https://github.com/hanress/helm-timescale
 name: timescaledb
-version: 0.2.20
+version: 0.2.21
 dependencies:
   - name: harness-common
     version: 1.x.x

--- a/src/timescale/values.yaml
+++ b/src/timescale/values.yaml
@@ -433,7 +433,6 @@ fullWalPrevention:
 
 resources: {}
 #  limits:
-#    cpu: "1"
 #    memory: "2048Mi"
 #  requests:
 #    cpu: "1"


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)